### PR TITLE
Added option 'allowsearch' to be able to display/hide the search box easily.

### DIFF
--- a/collective/plonefinder/browser/finder.pt
+++ b/collective/plonefinder/browser/finder.pt
@@ -72,7 +72,8 @@
                href="javascript: void(0);"
                onclick="Browser.maximize(); return false;">
             </a>
-            <div id="searchBrowserBox">
+            <div id="searchBrowserBox"
+                 tal:condition="view/allowsearch">
               <form id="finderSearchForm">
                 <input type="hidden"
                        name="searchsubmit:int"

--- a/collective/plonefinder/browser/finder.pt
+++ b/collective/plonefinder/browser/finder.pt
@@ -73,7 +73,7 @@
                onclick="Browser.maximize(); return false;">
             </a>
             <div id="searchBrowserBox"
-                 tal:condition="view/allowsearch">
+                 tal:condition="view/showsearchbox">
               <form id="finderSearchForm">
                 <input type="hidden"
                        name="searchsubmit:int"

--- a/collective/plonefinder/browser/finder.py
+++ b/collective/plonefinder/browser/finder.py
@@ -156,6 +156,8 @@ class Finder(BrowserView):
         self.ispopup = True
         #: True to show anyway blacklisted items (but these are not selectable)
         self.showblacklisted = True
+        #: True to display the search box
+        self.allowsearch = True
         #: True to display search results
         self.searchsubmit = False
         #: True to allow file upload through the finder

--- a/collective/plonefinder/browser/finder.py
+++ b/collective/plonefinder/browser/finder.py
@@ -157,7 +157,7 @@ class Finder(BrowserView):
         #: True to show anyway blacklisted items (but these are not selectable)
         self.showblacklisted = True
         #: True to display the search box
-        self.allowsearch = True
+        self.showsearchbox = True
         #: True to display search results
         self.searchsubmit = False
         #: True to allow file upload through the finder

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Added option 'allowsearch' to be able to display/hide the search box easily.
+- Added option 'showsearchbox' to be able to display/hide the search box easily.
   [gbastien]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added option 'allowsearch' to be able to display/hide the search box easily.
+  [gbastien]
 
 
 1.1.1 (2016-02-23)


### PR DESCRIPTION
Hi @gotcha @bsuttor @kiorky 

could you please review this and merge if it is ok?  It just adds an option "allowsearch" to be able to display/hide the search box.

Thank you,

Gauthier