### PR TITLE
Added option 'openuploadwidgetdefault' 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,6 +194,9 @@ Full list of customization attributes
      - ``False``
      - Do we enable upload files through our widget if the user has appropriate
        permission? See `Uploadding in custom folderish type`_
+   * - ``openuploadwidgetdefault``
+     - ``False``
+     - Do we display the upload widget by default?
    * - ``allowaddfolder``
      - ``False``
      - Do we enable adding new folders through our widget if the user has

--- a/collective/plonefinder/browser/finder.pt
+++ b/collective/plonefinder/browser/finder.pt
@@ -138,6 +138,13 @@
                  title="upload"
                  href="javascript: void(0);"
                  onclick="Browser.openUploader();return false">
+                 <tal:openUploaderDefault condition="view/openuploadwidgetdefault">
+                  <script type="text/javascript">
+                   jQuery(document).ready(function($) {
+                   Browser.openUploader();
+                   });
+                  </script>
+                 </tal:openUploaderDefault>
                  <span i18n:translate="label_files_quick__upload">Files quick upload</span>
               </a>
               <a class="addFolderView"

--- a/collective/plonefinder/browser/finder.py
+++ b/collective/plonefinder/browser/finder.py
@@ -162,6 +162,8 @@ class Finder(BrowserView):
         self.searchsubmit = False
         #: True to allow file upload through the finder
         self.allowupload = False
+        #: True to display upload widget by default, only relevant if self.allowupload = True
+        self.openuploadwidgetdefault = False
         #: True to allow creating new folders through the finder
         self.allowaddfolder = False
         #: Portal type built to hold object upload through finder UI

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added option 'openuploadwidgetdefault' to be able to specify if we want
+  the upload widget to be opened by default without having to click on the
+  'Files quick upload' button.
+  [gbastien]
 
 
 1.1.2 (2016-03-15)


### PR DESCRIPTION
to be able to specify if we want the upload widget to be opened by default without having to click on the 'Files quick upload' button.

@gotcha could you review this?

Thank you!

Gauthier