### PR TITLE
Fix bug in finder's query form serialization with special characters

### DIFF
--- a/collective/plonefinder/browser/static/finder.js
+++ b/collective/plonefinder/browser/static/finder.js
@@ -179,7 +179,7 @@ function getQueryObject(query) {
         var KeyVal = Pairs[i].split('=');
         if (! KeyVal || KeyVal.length != 2) continue;
         var key = KeyVal[0];
-        var kvalue = unescape(KeyVal[1]);
+        var kvalue = decodeURI(KeyVal[1]);
         if (isInString(':list', key)) {
             if (typeof listDatas[key] != 'undefined') {
                 // trop nul le javascript

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,9 @@ Changelog
   'Files quick upload' button.
   [gbastien]
 
+- Fix bug in finder's query form serialization with special characters.
+  [pgrunewald]
+
 
 1.1.2 (2016-03-15)
 ------------------


### PR DESCRIPTION
For further discussion see:

* http://www.w3schools.com/jsref/jsref_unescape.asp
* https://stackoverflow.com/questions/619323/decodeuricomponent-vs-unescape-what-is-wrong-with-unescape

I would be delighted to see this merged. :)

regards