### PR TITLE
Remove portal properties usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='collective.plonefinder',
           # -*- Extra requirements: -*-
           'collective.quickupload',
           'plone.api',
+          'plone.app.imaging',
           ],
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
I'd like to (slowly) move forward with pushing collective.ckeditor and collective.plonefinder to Plone 5. 
First step: remove portal_properties usage